### PR TITLE
Add `post_count` for free plan users in `add_post` api

### DIFF
--- a/backend/src/add_post.rs
+++ b/backend/src/add_post.rs
@@ -113,10 +113,12 @@ impl NewPost {
     }
 }
 
+/// Returns the number of posts by the user_id whose subscription is free trial
 fn post_count_by_user_id(conn: &mut ft_sdk::Connection, user_id: i64) -> Option<i64> {
     use common::schema::{posts, users};
     use diesel::prelude::*;
 
+    // Get the subscription type of the user
     let subscription_type: Option<String> = users::table
         .filter(users::id.eq(user_id))
         .select(users::subscription_type)

--- a/backend/src/add_post.rs
+++ b/backend/src/add_post.rs
@@ -1,5 +1,3 @@
-use diesel::ExpressionMethods;
-
 #[ft_sdk::data]
 fn add_post(
     mut conn: ft_sdk::Connection,

--- a/backend/src/add_post.rs
+++ b/backend/src/add_post.rs
@@ -114,7 +114,10 @@ impl NewPost {
 }
 
 /// Returns the number of posts by the user_id whose subscription is free trial
-fn post_count_by_user_id(conn: &mut ft_sdk::Connection, user_id: i64) -> Result<Option<i64>, ft_sdk::Error> {
+fn post_count_by_user_id(
+    conn: &mut ft_sdk::Connection,
+    user_id: i64,
+) -> Result<Option<i64>, ft_sdk::Error> {
     use common::schema::{posts, users};
     use diesel::prelude::*;
 
@@ -124,7 +127,11 @@ fn post_count_by_user_id(conn: &mut ft_sdk::Connection, user_id: i64) -> Result<
         .select(users::subscription_type)
         .get_result::<Option<String>>(conn)
         .map_err(|e| {
-            ft_sdk::println!("Error fetching subscription type for user {}: {:?}", user_id, e);
+            ft_sdk::println!(
+                "Error fetching subscription type for user {}: {:?}",
+                user_id,
+                e
+            );
             ft_sdk::Error::from(e)
         })?;
 
@@ -146,7 +153,6 @@ fn post_count_by_user_id(conn: &mut ft_sdk::Connection, user_id: i64) -> Result<
     }
 }
 
-
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("diesel error {0}")]
@@ -154,9 +160,6 @@ pub enum Error {
     #[error("{0}")]
     Custom(String),
 }
-
-
-
 
 #[derive(serde::Serialize)]
 pub struct Output {

--- a/backend/src/free_trial.rs
+++ b/backend/src/free_trial.rs
@@ -70,7 +70,6 @@ fn subscribe_free_trial_for_user(
     Ok(())
 }
 
-
 #[derive(Debug, serde::Serialize)]
 struct GupshupUserData {
     phone: String,


### PR DESCRIPTION
- `Subscription Check:` The function first retrieves the user's subscription type from the database.

- `Free Plan Verification:` Checks if the subscription type matches the free trial plan. 

- `Count Posts:` If the user is on the free plan, the function counts the number of posts associated with the user and returns this count.

- `Return None:` If the user is not on the free plan, the function returns None.

## Below `JSON` responses show the status `before` and `after` subscribing to the `Free Trial Plan`:

-  Before Subscribing to Free Trial

```json
{
    "message": "Please upgrade your subscription.",
    "success": false
}
```

- After Subscribing to Free Trial Plan and Adding First Post

```json
{
    "data": {
        "createdon": "2024-09-14 18:45:30",
        "mediaurl": "https://w0.peakpx.com/wallpaper/42/267/HD-wallpaper-nature-scenery-scenery-nature.jpg",
        "postcontent": "Purple beauty\\n\\nWhen the earth and the sky become one.",
        "postcount": 1,
        "postid": 22,
        "randompost": {
            "content": "",
            "date": "",
            "mediaurl": "",
            "time_ago": ""
        }
    },
    "message": "Post added successfully.",
    "success": true
}
```

